### PR TITLE
 Add more `const fn` functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_std = ["std", "serde/std"]
 serde = { version = "^1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
-assert_matches = "1.3.0"
+assert_matches = "1.5.0"
 
 [package.metadata.docs.rs]
 features = ["serde", "serde_std"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,6 +4,6 @@ version = "Two"
 wrap_comments = true
 comment_width = 120
 max_width = 120
-merge_imports = false
+imports_granularity="Preserve"
 newline_style = "Unix"
 struct_lit_single_line = false

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -21,7 +21,7 @@ impl MacAddr {
     /// assert_eq!(addr.is_v6(), true);
     /// assert_eq!(addr.is_v8(), false);
     /// ```
-    pub fn is_v6(&self) -> bool {
+    pub const fn is_v6(&self) -> bool {
         match self {
             MacAddr::V6(_) => true,
             MacAddr::V8(_) => false,
@@ -39,7 +39,7 @@ impl MacAddr {
     /// assert_eq!(addr.is_v6(), false);
     /// assert_eq!(addr.is_v8(), true);
     /// ```
-    pub fn is_v8(&self) -> bool {
+    pub const fn is_v8(&self) -> bool {
         match self {
             MacAddr::V6(_) => false,
             MacAddr::V8(_) => true,
@@ -58,7 +58,7 @@ impl MacAddr {
     ///
     /// assert_eq!(addr.as_bytes(), &[0xAC, 0xDE, 0x48, 0x23, 0x45, 0x67]);
     /// ```
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         match self {
             MacAddr::V6(addr) => addr.as_bytes(),
             MacAddr::V8(addr) => addr.as_bytes(),

--- a/src/addr6.rs
+++ b/src/addr6.rs
@@ -148,7 +148,7 @@ impl MacAddr6 {
     ///
     /// assert_eq!(addr.as_bytes(), &[0xAC, 0xDE, 0x48, 0x23, 0x45, 0x67]);
     /// ```
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 

--- a/src/addr8.rs
+++ b/src/addr8.rs
@@ -148,7 +148,7 @@ impl MacAddr8 {
     ///
     /// assert_eq!(addr.as_bytes(), &[0xAC, 0xDE, 0x48, 0x23, 0x45, 0x67, 0x89, 0xAB]);
     /// ```
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -62,7 +62,7 @@ pub struct Parser<'a> {
 }
 
 impl<'a> Parser<'a> {
-    pub fn new(s: &'a str) -> Parser<'a> {
+    pub const fn new(s: &'a str) -> Parser<'a> {
         Parser {
             source: s.as_bytes(),
             pos: 0,
@@ -70,7 +70,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn is_eof(&self) -> bool {
+    const fn is_eof(&self) -> bool {
         self.pos == self.source.len()
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9,7 +9,7 @@ use crate::{MacAddr, MacAddr6, MacAddr8};
 /// An error which can be returned when parsing MAC address.
 ///
 /// This error is used as the error type for the `FromStr` implementation
-/// for [MacAddr6] and [MacAddr8].
+/// for [`MacAddr6`] and [`MacAddr8`].
 ///
 /// [MacAddr6]: ./struct.MacAddr6.html
 /// [MacAddr8]: ./struct.MacAddr8.html


### PR DESCRIPTION
This PR aims to convert all the possibles functions to `const fn` in order to be used in other `const fn` environments, but also includes several changes to cleanup the code. I have also updated `assert_matches` to the latest version and replaced the deprecated `merge_imports ` with `imports_granularity` in the `rustfmt.toml`.

As a downside, these changes bumps the MSRV to the [1.46.0](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html).