### PR TITLE
Provide constructors that take arrays

### DIFF
--- a/src/addr6.rs
+++ b/src/addr6.rs
@@ -22,6 +22,18 @@ impl MacAddr6 {
         MacAddr6([a, b, c, d, e, f])
     }
 
+    /// Creates a new `MacAddr6` address from an array of bytes.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use macaddr::MacAddr6;
+    /// let addr = MacAddr6::new_from_array([0x01, 0x23, 0x45, 0x67, 0x89, 0xAB]);
+    /// ```
+    pub const fn new_from_array(arr: [u8; 6]) -> MacAddr6 {
+        MacAddr6(arr)
+    }
+
     /// Create a new nil `MacAddr6`.
     ///
     /// ## Example

--- a/src/addr8.rs
+++ b/src/addr8.rs
@@ -22,6 +22,18 @@ impl MacAddr8 {
         MacAddr8([a, b, c, d, e, f, g, h])
     }
 
+    /// Creates a new `MacAddr8` address from an array of bytes.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use macaddr::MacAddr8;
+    /// let addr = MacAddr8::new_from_array([0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF]);
+    /// ```
+    pub const fn new_from_array(arr: [u8; 8]) -> MacAddr8 {
+        MacAddr8(arr)
+    }
+
     /// Create a new nil `MacAddr8`.
     ///
     /// ## Example


### PR DESCRIPTION
Is there a reason the constructor with individual bytes as args is preferred to passing an array?