### PR TITLE
Rename `into_array` to `octets`.

### DIFF
--- a/src/addr6.rs
+++ b/src/addr6.rs
@@ -162,7 +162,26 @@ impl MacAddr6 {
     ///
     /// assert_eq!(addr.into_array(), [0xAC, 0xDE, 0x48, 0x23, 0x45, 0x67]);
     /// ```
+    #[deprecated(
+        since = "1.1.0",
+        note = "Renamed to `octets` to mirror the standard library's `IpAddr` types."
+    )]
     pub const fn into_array(self) -> [u8; 6] {
+        self.0
+    }
+
+    /// Returns the six eight-bit integers the MAC address consists of.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use macaddr::MacAddr6;
+    /// let addr = MacAddr6::new(0xAC, 0xDE, 0x48, 0x23, 0x45, 0x67);
+    ///
+    /// assert_eq!(addr.octets(), [0xAC, 0xDE, 0x48, 0x23, 0x45, 0x67]);
+    /// ```
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub const fn octets(&self) -> [u8; 6] {
         self.0
     }
 }

--- a/src/addr8.rs
+++ b/src/addr8.rs
@@ -162,7 +162,26 @@ impl MacAddr8 {
     ///
     /// assert_eq!(addr.into_array(), [0xAC, 0xDE, 0x48, 0x23, 0x45, 0x67, 0x89, 0xAB]);
     /// ```
+    #[deprecated(
+        since = "1.1.0",
+        note = "Renamed to `octets` to mirror the standard library's `IpAddr` types."
+    )]
     pub const fn into_array(self) -> [u8; 8] {
+        self.0
+    }
+
+    /// Returns the eight eight-bit integers the MAC address consists of.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use macaddr::MacAddr8;
+    /// let addr = MacAddr8::new(0xAC, 0xDE, 0x48, 0x23, 0x45, 0x67, 0x89, 0xAB);
+    ///
+    /// assert_eq!(addr.octets(), [0xAC, 0xDE, 0x48, 0x23, 0x45, 0x67, 0x89, 0xAB]);
+    /// ```
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub const fn octets(&self) -> [u8; 8] {
         self.0
     }
 }


### PR DESCRIPTION
The name `into_array` feels a bit out of place. Most methods of this type in the standard library are called `to_bytes` taking `&self`. The `IpAddr` types call it `octets` however.

Given there is already `as_bytes`, maybe calling it `to_bytes` is the better option.