### PR TITLE
Allow omitting leading zeros while parsing.

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -135,6 +135,14 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn read_octet(&mut self) -> Result<u8, ParseError> {
+        let mut digit = self.read_digit()?;
+        if self.probe_delimiter()?.is_none() && !self.is_eof() {
+            digit = (digit << 4) | self.read_digit()?;
+        }
+        Ok(digit)
+    }
+
     pub fn read_v6_addr(&mut self) -> Result<MacAddr6, ParseError> {
         let mut bytes = [0; 6];
         let mut i = 0;
@@ -144,10 +152,7 @@ impl<'a> Parser<'a> {
                 self.move_next();
             }
 
-            let mut digit = self.read_digit()? * 16;
-            digit += self.read_digit()?;
-
-            bytes[i] = digit;
+            bytes[i] = self.read_octet()?;
 
             i += 1;
         }
@@ -168,10 +173,7 @@ impl<'a> Parser<'a> {
                 self.move_next();
             }
 
-            let mut digit = self.read_digit()? * 16;
-            digit += self.read_digit()?;
-
-            bytes[i] = digit;
+            bytes[i] = self.read_octet()?;
 
             i += 1;
         }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -120,31 +120,33 @@ fn test_parse_empty() {
 }
 
 #[test]
-fn test_parse_v6_partial_start() {
-    let addr = MacAddr6::from_str("b-cd-ef-12-34-56");
-
-    assert!(addr.is_err());
+fn test_parse_v6_partial() {
+    assert!(MacAddr6::from_str("cd-ef-12-34-56").is_err());
+    assert!(MacAddr6::from_str("ab-cd-ef-12-34-").is_err());
 }
 
 #[test]
-fn test_parse_v8_partial_start() {
-    let addr = MacAddr8::from_str("b-cd-ef-12-34-56-78-9A");
-
-    assert!(addr.is_err());
+fn test_parse_v8_partial() {
+    assert!(MacAddr8::from_str("cd-ef-12-34-56-78-9A").is_err());
+    assert!(MacAddr8::from_str("ab-cd-ef-12-34-56-78-").is_err());
 }
 
 #[test]
-fn test_parse_v6_partial_end() {
-    let addr = MacAddr6::from_str("ab-cd-ef-12-34-5");
-
-    assert!(addr.is_err());
+fn test_parse_v6_missing_leading_zeros() {
+    let addr = MacAddr::from_str("1:34:6:7:9A:B");
+    assert!(addr.is_ok());
+    let addr = addr.unwrap();
+    assert_matches!(addr, MacAddr::V6(..));
+    assert_eq!(&[0x1, 0x34, 0x6, 0x7, 0x9A, 0xB], addr.as_bytes());
 }
 
 #[test]
-fn test_parse_v8_partial_end() {
-    let addr = MacAddr8::from_str("ab-cd-ef-12-34-56-78-9");
-
-    assert!(addr.is_err());
+fn test_parse_v8_missing_leading_zeros() {
+    let addr = MacAddr::from_str("1:34:56:7:9A:BC:D:F");
+    assert!(addr.is_ok());
+    let addr = addr.unwrap();
+    assert_matches!(addr, MacAddr::V8(..));
+    assert_eq!(&[0x1, 0x34, 0x56, 0x7, 0x9A, 0xBC, 0xD, 0xF], addr.as_bytes());
 }
 
 #[test]


### PR DESCRIPTION
A bit of a papercut but this definitely bit me when piping a mac address from a tool that emits them without leading zeros to one using this crate that expects them.